### PR TITLE
change the workflow triggers to manual so they don't run on every commit

### DIFF
--- a/.github/workflows/Etcher-arm64.yml
+++ b/.github/workflows/Etcher-arm64.yml
@@ -1,12 +1,7 @@
 name: Etcher-arm64
 
 on:
-  push:
-    branches: [ master ]
-    paths-ignore: [README.md]
-  pull_request:
-    branches: [ master ]
-    paths-ignore: [README.md]
+  workflow_dispatch:
 
 jobs:
   build-arm64:

--- a/.github/workflows/Freetube-armhf.yml
+++ b/.github/workflows/Freetube-armhf.yml
@@ -1,9 +1,7 @@
 name: build-freetube-armhf
 
 on:
-  push:
-    branches: [ master ]
-    paths-ignore: [README.md]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/stuntrally-arm64.yml
+++ b/.github/workflows/stuntrally-arm64.yml
@@ -1,12 +1,7 @@
 name: stuntrally-arm64
 
 on:
-  push:
-    branches: [ master ]
-    paths-ignore: [README.md]
-  pull_request:
-    branches: [ master ]
-    paths-ignore: [README.md]
+  workflow_dispatch:
 
 jobs:
   stuntrally-arm64:


### PR DESCRIPTION
I changed the trigger for the workflows to be manual so they don't run on every commit. you can start each one from the actions tab, look how it is in my fork.